### PR TITLE
feat:navegacion de user-home a canal-display

### DIFF
--- a/canal-display.html
+++ b/canal-display.html
@@ -37,22 +37,22 @@
             <!-- Sidebar Izquierdo -->
             <aside class="sidebar-left">
                 <div class="menu">
-                    <div class="menu-item">
+                    <a href="user-home.html" class="menu-item" style="text-decoration:none; color:inherit;">
                         Home
                         <span class="material-symbols-outlined">home</span>
-                    </div>
+                    </a>
                     <div class="menu-item">
                         Explorar Categorías
                         <span class="material-symbols-outlined">explore</span>
                     </div>
-                    <div class="menu-item">
+                    <a href="creadores-sugeridos.html" class="menu-item" style="text-decoration:none; color:inherit;">
                         Creadores Sugeridos
                         <span class="material-symbols-outlined">emoji_people</span>
-                    </div>
-                    <div class="menu-item">
+                    </a>
+                    <a href="Configuracion-home.html" class="menu-item" style="text-decoration:none; color:inherit;">
                         Configurar
                         <span class="material-symbols-outlined">settings</span>
-                    </div>
+                    </a>
                 </div>
                 <div class="live-channels">
                     <h3>Canales en Vivo</h3>

--- a/user-home.html
+++ b/user-home.html
@@ -1,223 +1,111 @@
 <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <title>Home</title>
-        <!-- Google Material Symbols -->
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
-        <link rel="stylesheet" href="/style/styles.css" />
-    </head>
-    <body>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Home</title>
+    <!-- Google Material Symbols -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" />
+    <link rel="stylesheet" href="/style/styles.css" />
+</head>
+<body>
 
-        <!-- Navbar superior -->
-        <header class="navbar">
-            <div class="logo">Krowd</div>
-            <div class="search">
-                <span class="search-icon material-symbols-outlined">search</span>
-                <input type="search" placeholder="Buscar" class="search-input">
+    <!-- Navbar superior -->
+    <header class="navbar">
+        <div class="logo">Krowd</div>
+        <div class="search">
+            <span class="search-icon material-symbols-outlined">search</span>
+            <input type="search" placeholder="Buscar" class="search-input">
+        </div>
+        <div class="user-info">
+            <div class="user-item">
+                <span class="material-symbols-outlined">stars</span>
+                0 Créditos
             </div>
-            <div class="user-info">
-                <div class="user-item">
-                    <span class="material-symbols-outlined">stars</span>
-                    0 Créditos
+            <div class="user-item">
+                <span class="material-symbols-outlined">notifications</span>
+            </div>
+            <div class="user-item">
+                <span class="material-symbols-outlined">person</span>
+                xXCamiloXx
+            </div>
+        </div>
+
+    </header>
+
+    <div class="layout">
+        <!-- Sidebar Izquierdo -->
+        <aside class="sidebar-left">
+            <div class="menu">
+                <div class="menu-item active">
+                    Home
+                    <span class="material-symbols-outlined">home</span>
                 </div>
-                <div class="user-item">
-                    <span class="material-symbols-outlined">notifications</span>
+                <div class="menu-item">
+                    Explorar Categorías
+                    <span class="material-symbols-outlined">explore</span>
                 </div>
-                <div class="user-item">
-                    <span class="material-symbols-outlined">person</span>
-                    xXCamiloXx
+                <a href="creadores-sugeridos.html" class="menu-item" style="text-decoration:none; color:inherit;">
+                    Creadores Sugeridos
+                    <span class="material-symbols-outlined">emoji_people</span>
+                </a>
+                <a href="Configuracion-home.html" class="menu-item" style="text-decoration:none; color:inherit;">
+                    Configurar
+                    <span class="material-symbols-outlined">settings</span>
+                </a>
+            </div>
+            <div class="live-channels">
+                <h3>Canales en Vivo</h3>
+                <!-- Lista de canales en vivo -->
+                <div class="channel">
+                    <img src="/assets/streamer1.png" class="avatar" alt="LuriShow">
+                    <div class="info">
+                        <div class="name">LuriShow</div>
+                        <div class="category">IRL</div>
+                    </div>
+                    <div class="viewers"><span class="dot"></span>1K</div>
+                </div>
+                <div class="channel">
+                    <img src="/assets/streamer2.png" class="avatar" alt="Canal 2">
+                    <div class="info">
+                        <div class="name">Shadowki</div>
+                        <div class="category">Just Chatting</div>
+                    </div>
+                    <div class="viewers"><span class="dot"></span>500</div>
+                </div>
+                <div class="channel">
+                    <img src="/assets/streamer3.png" class="avatar" alt="Canal 3">
+                    <div class="info">
+                        <div class="name">MakanAx</div>
+                        <div class="category">Música</div>
+                    </div>
+                    <div class="viewers"><span class="dot"></span>2K</div>
+                </div>
+                <div class="channel">
+                    <img src="/assets/streamer4.png" class="avatar" alt="Canal 4">
+                    <div class="info">
+                        <div class="name">PirulETv</div>
+                        <div class="category">Arte</div>
+                    </div>
+                    <div class="viewers"><span class="dot"></span>300</div>
+                </div>
+                <div class="channel">
+                    <img src="/assets/streamer5.png" class="avatar" alt="Canal 5">
+                    <div class="info">
+                        <div class="name">CamiloXX</div>
+                        <div class="category">Charlas</div>
+                    </div>
+                    <div class="viewers"><span class="dot"></span>800</div>
                 </div>
             </div>
+        </aside>
 
-        </header>
-
-        <div class="layout">
-            <!-- Sidebar Izquierdo -->
-            <aside class="sidebar-left">
-                <div class="menu">
-                    <div class="menu-item active">
-                        Home
-                        <span class="material-symbols-outlined">home</span>
-                    </div>
-                    <div class="menu-item">
-                        Explorar Categorías
-                        <span class="material-symbols-outlined">explore</span>
-                    </div>
-                    <a href="creadores-sugeridos.html" class="menu-item" style="text-decoration:none; color:inherit;">
-                        Creadores Sugeridos
-                        <span class="material-symbols-outlined">emoji_people</span>
-                    </a>
-                    <a href="Configuracion-home.html" class="menu-item" style="text-decoration:none; color:inherit;">
-                        Configurar
-                        <span class="material-symbols-outlined">settings</span>
-                    </a>
-                </div>
-                <div class="live-channels">
-                    <h3>Canales en Vivo</h3>
-                    <!-- Lista de canales en vivo -->
-                    <div class="channel">
-                        <img src="/assets/streamer1.png" class="avatar" alt="LuriShow">
-                        <div class="info">
-                            <div class="name">LuriShow</div>
-                            <div class="category">IRL</div>
-                        </div>
-                        <div class="viewers"><span class="dot"></span>1K</div>
-                    </div>
-                    <div class="channel">
-                        <img src="/assets/streamer2.png" class="avatar" alt="Canal 2">
-                        <div class="info">
-                            <div class="name">Shadowki</div>
-                            <div class="category">Just Chatting</div>
-                        </div>
-                        <div class="viewers"><span class="dot"></span>500</div>
-                    </div>
-                    <div class="channel">
-                        <img src="/assets/streamer3.png" class="avatar" alt="Canal 3">
-                        <div class="info">
-                            <div class="name">MakanAx</div>
-                            <div class="category">Música</div>
-                        </div>
-                        <div class="viewers"><span class="dot"></span>2K</div>
-                    </div>
-                    <div class="channel">
-                        <img src="/assets/streamer4.png" class="avatar" alt="Canal 4">
-                        <div class="info">
-                            <div class="name">PirulETv</div>
-                            <div class="category">Arte</div>
-                        </div>
-                        <div class="viewers"><span class="dot"></span>300</div>
-                    </div>
-                    <div class="channel">
-                        <img src="/assets/streamer5.png" class="avatar" alt="Canal 5">
-                        <div class="info">
-                            <div class="name">CamiloXX</div>
-                            <div class="category">Charlas</div>
-                        </div>
-                        <div class="viewers"><span class="dot"></span>800</div>
-                    </div>
-                </div>
-            </aside>
-
-            <!-- Contenido principal -->
-            <main class="content">
-                <!-- Sección Videojuegos -->
-                <div class="videojuegos">
-                    <h1>Videojuegos</h1>
-                    <div class="live-grid">
-                        <!-- Tarjetas de streams de videojuegos -->
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">1 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 2" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">Shadowki</div>
-                                <div class="stream-category">Just Chatting</div>
-                                <div class="stream-viewers">2 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 3" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">MakanAx</div>
-                                <div class="stream-category">Música</div>
-                                <div class="stream-viewers">3 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 4" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">PirulETv</div>
-                                <div class="stream-category">Arte</div>
-                                <div class="stream-viewers">4 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 5" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">CamiloXX</div>
-                                <div class="stream-category">Charlas</div>
-                                <div class="stream-viewers">5 viewers</div>
-                            </div>
-                        </div>
-                        <!-- Más tarjetas de ejemplo -->
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">6 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">7 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">10 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">11 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">12 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">14 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">14 viewers</div>
-                            </div>
-                        </div>
-                        <div class="stream-card">
-                            <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                            <div class="stream-info">
-                                <div class="stream-title">LuriShow</div>
-                                <div class="stream-category">IRL</div>
-                                <div class="stream-viewers">15 viewers</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Sección Just Chatting -->
-                <div class="just-chatting">
-                    <h1>Just Chatting</h1>
+        <!-- Contenido principal -->
+        <main class="content">
+            <!-- Sección Videojuegos -->
+            <div class="videojuegos">
+                <h1>Videojuegos</h1>
                 <div class="live-grid">
-                    <!-- Tarjetas de streams de Just Chatting -->
+                    <!-- Tarjetas de streams de videojuegos -->
                     <div class="stream-card">
                         <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
                         <div class="stream-info">
@@ -258,6 +146,7 @@
                             <div class="stream-viewers">5 viewers</div>
                         </div>
                     </div>
+                    <!-- Más tarjetas de ejemplo -->
                     <div class="stream-card">
                         <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
                         <div class="stream-info">
@@ -272,22 +161,6 @@
                             <div class="stream-title">LuriShow</div>
                             <div class="stream-category">IRL</div>
                             <div class="stream-viewers">7 viewers</div>
-                        </div>
-                    </div>
-                    <div class="stream-card">
-                        <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                        <div class="stream-info">
-                            <div class="stream-title">LuriShow</div>
-                            <div class="stream-category">IRL</div>
-                            <div class="stream-viewers">8 viewers</div>
-                        </div>
-                    </div>
-                    <div class="stream-card">
-                        <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
-                        <div class="stream-info">
-                            <div class="stream-title">LuriShow</div>
-                            <div class="stream-category">IRL</div>
-                            <div class="stream-viewers">9 viewers</div>
                         </div>
                     </div>
                     <div class="stream-card">
@@ -319,7 +192,7 @@
                         <div class="stream-info">
                             <div class="stream-title">LuriShow</div>
                             <div class="stream-category">IRL</div>
-                            <div class="stream-viewers">13 viewers</div>
+                            <div class="stream-viewers">14 viewers</div>
                         </div>
                     </div>
                     <div class="stream-card">
@@ -339,30 +212,164 @@
                         </div>
                     </div>
                 </div>
+            </div>
+            <!-- Sección Just Chatting -->
+            <div class="just-chatting">
+                <h1>Just Chatting</h1>
+            <div class="live-grid">
+                <!-- Tarjetas de streams de Just Chatting -->
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">1 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 2" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">Shadowki</div>
+                        <div class="stream-category">Just Chatting</div>
+                        <div class="stream-viewers">2 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 3" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">MakanAx</div>
+                        <div class="stream-category">Música</div>
+                        <div class="stream-viewers">3 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 4" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">PirulETv</div>
+                        <div class="stream-category">Arte</div>
+                        <div class="stream-viewers">4 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 5" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">CamiloXX</div>
+                        <div class="stream-category">Charlas</div>
+                        <div class="stream-viewers">5 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">6 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">7 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">8 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">9 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">10 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">11 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">12 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">13 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">14 viewers</div>
+                    </div>
+                </div>
+                <div class="stream-card">
+                    <img src="/assets/genericstreamerimage.jpg" alt="Stream 1" class="stream-thumb" />
+                    <div class="stream-info">
+                        <div class="stream-title">LuriShow</div>
+                        <div class="stream-category">IRL</div>
+                        <div class="stream-viewers">15 viewers</div>
+                    </div>
+                </div>
+            </div>
 
-                </div>
-            </main>
+            </div>
+        </main>
 
-            <!-- Sidebar Derecho -->
-            <aside class="sidebar-right">
-                <div class="trends">
-                    Tendencias
-                    <span class="material-symbols-outlined">local_fire_department</span>
-                </div>
-                <div class="menu-item">
-                    <span>#</span>Just Chatting
-                </div>
-                <div class="menu-item">
-                    <span>#</span>IRL
-                </div>
-                <div class="menu-item">
-                    <span>#</span>GTA V
-                </div>
-                <div class="menu-item">
-                    <span>#</span>Valorant
-                </div>
-            </aside>
-        </div>
-
-    </body>
-    </html>
+        <!-- Sidebar Derecho -->
+        <aside class="sidebar-right">
+            <div class="trends">
+                Tendencias
+                <span class="material-symbols-outlined">local_fire_department</span>
+            </div>
+            <div class="menu-item">
+                <span>#</span>Just Chatting
+            </div>
+            <div class="menu-item">
+                <span>#</span>IRL
+            </div>
+            <div class="menu-item">
+                <span>#</span>GTA V
+            </div>
+            <div class="menu-item">
+                <span>#</span>Valorant
+            </div>
+        </aside>
+    </div>
+    <script>
+document.querySelectorAll('.stream-card').forEach(card => {
+    card.style.cursor = "pointer";
+    card.addEventListener('click', function() {
+        window.location.href = "canal-display.html";
+    });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Se implementó navegación interactiva en la plataforma. Ahora, desde el menú lateral izquierdo de cualquier página, los usuarios pueden acceder fácilmente a Home, Configuración y Creadores Sugeridos. Además, al hacer clic en cualquier miniatura de canal en las grillas de la página principal, el usuario es dirigido automáticamente a la página de visualización del canal seleccionado.